### PR TITLE
fix(consle/lights): lights can now be walked thru

### DIFF
--- a/consle.lua
+++ b/consle.lua
@@ -608,6 +608,7 @@ minetest.register_node("tardis_new:light"..set, {
 		drawtype = "signlike",
 		paramtype = "light",
 		sunlight_propagates = true,
+		walkable = false, -- Allow players to walk thru them (rather than blocking their movement)
 		light_source = minetest.LIGHT_MAX,
 		paramtype2 = "wallmounted",
 		selection_box = { type = "wallmounted" },


### PR DESCRIPTION
Just like a default:torch (which can be walked thru) now the lights from this mod can too.

> default:torch has a [flag](https://github.com/minetest/minetest_game/blob/master/mods/default/torch.lua#L36) which allows players to walk thru it.

I stumbled upon this while making a few changes. (Added a single style of light but allowing it to be turned on or off just by punching it)
